### PR TITLE
Removed memory bit flags

### DIFF
--- a/bin/printer.py
+++ b/bin/printer.py
@@ -514,7 +514,6 @@ class Printer:
 				("e", "size", self.__sim.lib.sal_mem_get_size),
 				("e", "blocks", self.__sim.lib.sal_mem_get_block_start_count),
 				("e", "allocated", self.__sim.lib.sal_mem_get_allocated_count),
-				("e", "ips", self.__sim.lib.sal_mem_get_ip_count),
 				("s", ""),
 				("h", "INSTRUCTIONS"),
 			] + inst_widget),

--- a/bin/printer.py
+++ b/bin/printer.py
@@ -512,8 +512,7 @@ class Printer:
 			("MEMORY", [
 				("e", "order", self.__sim.lib.sal_mem_get_order),
 				("e", "size", self.__sim.lib.sal_mem_get_size),
-				("e", "blocks", self.__sim.lib.sal_mem_get_block_start_count),
-				("e", "allocated", self.__sim.lib.sal_mem_get_allocated_count),
+				("e", "allocated", self.__sim.lib.sal_mem_get_allocated),
 				("s", ""),
 				("h", "INSTRUCTIONS"),
 			] + inst_widget),

--- a/bin/world.py
+++ b/bin/world.py
@@ -41,7 +41,7 @@ class World:
 		line_width = self.__printer.size[1] - self.PADDING
 		print_area = self.__printer.size[0] * line_width
 		c_buffer = (c_uint8 * print_area)()
-		self.__sim.lib.sal_mem_render_image(
+		self.__sim.lib.sal_ren_get_image(
 			self.pos, self.zoom, print_area, cast(c_buffer, POINTER(c_uint8))
 		)
 

--- a/include/memory.h
+++ b/include/memory.h
@@ -10,7 +10,6 @@
 #ifndef SALIS_MEMORY_H
 #define SALIS_MEMORY_H
 
-#define IP_FLAG 0x80
 #define BLOCK_START_FLAG 0x40
 #define ALLOCATED_FLAG 0x20
 #define INSTRUCTION_MASK 0x1f
@@ -29,11 +28,6 @@ SALIS_API uint32 sal_mem_get_order(void);
 * @return Size of memory (memory_size == 1 << order)
 */
 SALIS_API uint32 sal_mem_get_size(void);
-
-/** Get amount of addresses with the IP flag set on them.
-* @return Amount of addresses with the IP flag set
-*/
-SALIS_API uint32 sal_mem_get_ip_count(void);
 
 /** Get amount of addresses with the memory-block-start flag set on them.
 * @return Amount of addresses with the memory-block-start flag set
@@ -67,12 +61,6 @@ SALIS_API boolean sal_mem_is_over_capacity(void);
 */
 SALIS_API boolean sal_mem_is_address_valid(uint32 address);
 
-/** Check if given address has the IP flag set.
-* @param address Address being queried
-* @return IP flag is set on this address
-*/
-SALIS_API boolean sal_mem_is_ip(uint32 address);
-
 /** Check if given address has the memory-block-start flag set.
 * @param address Address being queried
 * @return Memory-block-start flag is set on this address
@@ -85,10 +73,8 @@ SALIS_API boolean sal_mem_is_block_start(uint32 address);
 */
 SALIS_API boolean sal_mem_is_allocated(uint32 address);
 
-void _sal_mem_set_ip(uint32 address);
 void _sal_mem_set_block_start(uint32 address);
 void _sal_mem_set_allocated(uint32 address);
-void _sal_mem_unset_ip(uint32 address);
 void _sal_mem_unset_block_start(uint32 address);
 void _sal_mem_unset_allocated(uint32 address);
 

--- a/include/memory.h
+++ b/include/memory.h
@@ -3,14 +3,13 @@
 * @author Paul Oliver
 *
 * This module gives access to Salis memory. You can check the state of each
-* byte (instruction and flags) at any time and also perform manual memory
+* byte (instruction and alloc-flag) at any time and also perform manual memory
 * manipulations.
 */
 
 #ifndef SALIS_MEMORY_H
 #define SALIS_MEMORY_H
 
-#define BLOCK_START_FLAG 0x40
 #define ALLOCATED_FLAG 0x20
 #define INSTRUCTION_MASK 0x1f
 
@@ -29,15 +28,10 @@ SALIS_API uint32 sal_mem_get_order(void);
 */
 SALIS_API uint32 sal_mem_get_size(void);
 
-/** Get amount of addresses with the memory-block-start flag set on them.
-* @return Amount of addresses with the memory-block-start flag set
-*/
-SALIS_API uint32 sal_mem_get_block_start_count(void);
-
 /** Get amount of addresses with the allocated flag set on them.
 * @return Amount of addresses with the allocated flag set
 */
-SALIS_API uint32 sal_mem_get_allocated_count(void);
+SALIS_API uint32 sal_mem_get_allocated(void);
 
 /** Get memory capacity.
 * @return Memory capacity (capacity == size / 2)
@@ -61,28 +55,14 @@ SALIS_API boolean sal_mem_is_over_capacity(void);
 */
 SALIS_API boolean sal_mem_is_address_valid(uint32 address);
 
-/** Check if given address has the memory-block-start flag set.
-* @param address Address being queried
-* @return Memory-block-start flag is set on this address
-*/
-SALIS_API boolean sal_mem_is_block_start(uint32 address);
-
 /** Check if given address has the allocated flag set.
 * @param address Address being queried
 * @return Allocated flag is set on this address
 */
 SALIS_API boolean sal_mem_is_allocated(uint32 address);
 
-void _sal_mem_set_block_start(uint32 address);
 void _sal_mem_set_allocated(uint32 address);
-void _sal_mem_unset_block_start(uint32 address);
 void _sal_mem_unset_allocated(uint32 address);
-
-/** Get currently set flags at given address.
-* @param address Address being queried
-* @return Byte containing set flag bits
-*/
-SALIS_API uint8 sal_mem_get_flags(uint32 address);
 
 /** Get current instruction at address.
 * @param address Address being queried
@@ -98,7 +78,7 @@ SALIS_API void sal_mem_set_inst(uint32 address, uint8 inst);
 
 /** Get current byte at address.
 * @param address Address being queried
-* @return Byte currently written at address (includes bit flags & instruction)
+* @return Byte currently written at address (includes alloc-flag & instruction)
 */
 SALIS_API uint8 sal_mem_get_byte(uint32 address);
 

--- a/include/memory.h
+++ b/include/memory.h
@@ -82,19 +82,6 @@ SALIS_API void sal_mem_set_inst(uint32 address, uint8 inst);
 */
 SALIS_API uint8 sal_mem_get_byte(uint32 address);
 
-/** Render a 1D image of a given block of memory. This is useful, as rendering
-* directly in python would be too slow. We use openmp for multi-threaded image
-* generation.
-*
-* @param origin Low bound of rendered image
-* @param cell_size Amount of bytes per rendered pixel (cell)
-* @param buff_size Amount of pixels (cells) to be generated
-* @param buffer Pre-allocated buffer to store the rendered pixels into
-*/
-SALIS_API void sal_mem_render_image(
-	uint32 origin, uint32 cell_size, uint32 buff_size, uint8_p buffer
-);
-
 void _sal_mem_cycle(void);
 
 #endif

--- a/include/render.h
+++ b/include/render.h
@@ -1,0 +1,26 @@
+/**
+* @file render.h
+* @author Paul Oliver
+*
+* This module implements a multi-threaded memory render function that iterates
+* over a given area of memory and returns a 1D image. OMP is used to up
+* performance.
+*/
+
+#ifndef SALIS_RENDER_H
+#define SALIS_RENDER_H
+
+/** Render a 1D image of a given block of memory. This is useful, as rendering
+* directly in python would be too slow. We use openmp for multi-threaded image
+* generation.
+*
+* @param origin Low bound of rendered image
+* @param cell_size Amount of bytes per rendered pixel (cell)
+* @param buff_size Amount of pixels (cells) to be generated
+* @param buffer Pre-allocated buffer to store the rendered pixels into
+*/
+SALIS_API void sal_ren_get_image(
+	uint32 origin, uint32 cell_size, uint32 buff_size, uint8_p buffer
+);
+
+#endif

--- a/src/render.c
+++ b/src/render.c
@@ -1,0 +1,93 @@
+#include <assert.h>
+#include <stdio.h>
+#include "types.h"
+#include "memory.h"
+#include "process.h"
+#include "render.h"
+
+#define MAX_ZOOM 0x10000
+#define BLOCK_FLAG 0x40
+#define IP_FLAG 0x80
+
+static void apply_flag(
+	uint32 origin, uint32 max_pos, uint32 cell_size, uint32 address,
+	uint32 flag, uint8_p buffer
+) {
+	if (address >= origin && address < max_pos) {
+		/* Flag falls inside rendered image. We can 'and' the bit to the
+		corresponding pixel.
+		*/
+		uint32 pixel = (address - origin) / cell_size;
+		buffer[pixel] |= flag;
+	}
+}
+
+void sal_ren_get_image(
+	uint32 origin, uint32 cell_size, uint32 buff_size, uint8_p buffer
+) {
+	/* Render a 1D image of a given section of memory, at a given resolution
+	(zoom) and store it in a pre-allocated 'buffer'.
+
+	On the Salis python handler we draw memory as a 1D 'image' on the WORLD
+	page. If we were to render this image directly on python, it would be
+	excruciatingly slow, as we have to iterate over large areas of memory!
+	Therefore, this memory module comes with a built-in, super fast renderer.
+	*/
+	uint32 i;
+	uint32 max_pos;
+	assert(sal_mem_is_address_valid(origin));
+	assert(cell_size);
+	assert(cell_size <= MAX_ZOOM);
+	assert(buff_size);
+	assert(buffer);
+
+	/* We make use of openmp for multi-threaded looping. This allows even
+	faster render times, wherever openmp is supported.
+	*/
+	#pragma omp parallel for
+	for (i = 0; i < buff_size; i++) {
+		uint32 j;
+		uint32 inst_sum = 0;
+		uint32 alloc_flag = 0;
+		uint32 cell_addr = origin + (i * cell_size);
+
+		for (j = 0; j < cell_size; j++) {
+			uint32 address = j + cell_addr;
+
+			if (!sal_mem_is_address_valid(address)) {
+				continue;
+			}
+
+			inst_sum += sal_mem_get_inst(address);
+
+			if (sal_mem_is_allocated(address)) {
+				alloc_flag = ALLOCATED_FLAG;
+			}
+		}
+
+		buffer[i] = (uint8)(inst_sum / cell_size);
+		buffer[i] |= (uint8)(alloc_flag);
+	}
+
+	/* We also iterate through all processes and append extra bit flags to the
+	rendered image signaling process IP position and memory block limits.
+	*/
+	max_pos = origin + (cell_size * buff_size);
+
+	#pragma omp parallel for
+	for (i = 0; i < sal_proc_get_count(); i++) {
+		if (!sal_proc_is_free(i)) {
+			Process proc = sal_proc_get_proc(i);
+			apply_flag(origin, max_pos, cell_size, proc.ip, IP_FLAG, buffer);
+			apply_flag(
+				origin, max_pos, cell_size, proc.mb1a, BLOCK_FLAG, buffer
+			);
+
+			if (proc.mb2s) {
+				apply_flag(
+					origin, max_pos, cell_size, proc.mb2a, BLOCK_FLAG, buffer
+				);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Memory bit flags were merely an aesthetic component. I've replaced them with a new memory render function (in its own module) that applies bit flags on request. No bit flags are used now, with the exception of the ALLOCATED flag, inside the memory module.