### PR TITLE
Numeric cycle now times out.

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -32,7 +32,7 @@ $ ./bin/salis.py load --file 16.sim
 |`k`              |Scroll/go to selected (PROCESS and WORLD page) |
 |`X`              |Toggle hex/decimal value printing |
 |`M`              |Toggle minimal mode |
-|Numbers `[1..0]` |Cycle simulation `2^((n-1) % 10)` steps |
+|Numbers `[1..0]` |Cycle simulation `2^((n-1) % 10)` steps (max) |
 |Enter            |Activate cursor (WORLD page) |
 |Escape           |Save and quit simulation |
 

--- a/bin/handler.py
+++ b/bin/handler.py
@@ -20,12 +20,14 @@ console response. This ability gives an user a whole lot of power, and should
 be used with care.
 """
 
-import os
 import curses
+import os
+import time
 
 
 class Handler:
 	KEY_ESCAPE = 27
+	CYCLE_TIMEOUT = 0.1
 
 	def __init__(self, sim):
 		""" Handler constructor. Simply link this class to the main simulation
@@ -195,11 +197,17 @@ class Handler:
 		raise RuntimeError(message)
 
 	def __cycle_sim(self, factor):
-		""" Simply cycle Salis 'factor' number of times.
+		""" Simply cycle Salis 'factor' number of times. Do not cycle for more
+		than a given amount of time.
 		"""
+		time_max = time.time() + self.CYCLE_TIMEOUT
+
 		for _ in range(factor):
 			self.__sim.lib.sal_main_cycle()
 			self.__sim.check_autosave()
+
+			if time.time() > time_max:
+				break
 
 	def __get_inst_dict(self):
 		""" Transform the instruction list of the printer module into a


### PR DESCRIPTION
Using high numeric keys cycles simulation until a timeout is reached. This helps prevent Salis from hanging if a high number of cycles are requested.